### PR TITLE
Restaurar layout dashboard com rodapé

### DIFF
--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -8,6 +8,7 @@ const FooterContainer = styled.footer`
   padding: 20px 0;
   margin-top: auto;
   text-align: center;
+  flex-shrink: 0;
 `;
 
 const FooterContent = styled.div`

--- a/frontend/src/pages/AdminDashboardPage.js
+++ b/frontend/src/pages/AdminDashboardPage.js
@@ -22,6 +22,8 @@ const PageContainer = styled.div`
 const Container = styled.div`
   max-width: 1200px;
   margin: 0 auto;
+  width: 100%;
+  flex: 1;
 `;
 
 const PageHeader = styled.div`
@@ -54,9 +56,14 @@ const PageHeader = styled.div`
 
 const MetricsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 24px;
   margin-bottom: 40px;
+  
+  @media (max-width: 1200px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+  }
   
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
@@ -127,7 +134,7 @@ const MetricCard = styled.div`
 
 const QuickActionsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 24px;
   margin-bottom: 40px;
   


### PR DESCRIPTION
Restores the side-by-side layout of dashboard items while maintaining the footer's correct position.

---
<a href="https://cursor.com/background-agent?bcId=bc-35387d2e-8e4b-4b15-b9ff-23e8d27187e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35387d2e-8e4b-4b15-b9ff-23e8d27187e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

